### PR TITLE
Fix NPE in HoldPositionCharacteristic and null value in serialized characteristics

### DIFF
--- a/src/main/java/com/beowulfe/hap/characteristics/BaseCharacteristic.java
+++ b/src/main/java/com/beowulfe/hap/characteristics/BaseCharacteristic.java
@@ -172,7 +172,7 @@ public abstract class BaseCharacteristic<T> implements Characteristic {
 		} else if (value instanceof BigDecimal){
 			builder.add("value", (BigDecimal) value);
 		} else if (value == null) {
-			builder.addNull("value");
+			// Do not add null value, HomeKit cannot handle that
 		} else {
 			builder.add("value", value.toString());
 		}

--- a/src/main/java/com/beowulfe/hap/impl/characteristics/windowcovering/HoldPositionCharacteristic.java
+++ b/src/main/java/com/beowulfe/hap/impl/characteristics/windowcovering/HoldPositionCharacteristic.java
@@ -22,7 +22,7 @@ public class HoldPositionCharacteristic extends BooleanCharacteristic {
 	@Override
 	protected CompletableFuture<Boolean> getValue() {
 		//Write only
-		return null;
+		return CompletableFuture.completedFuture(null);
 	}
 
 }


### PR DESCRIPTION
I came up with 2 bugs when trying to implement a WindowCovering.
1. Got a null pointer exception in HoldPositionCharacteristic because getValue() returned null but should return a CompletableFuture.
2. After fixing that the created json looked like `"value": null`. Looks like HomeKit cannot handle null values. Completely omitting the value fixed the problem.

By the way: Nice work your HAP-Java :-)
