### PR TITLE
Added support for motion sensors and contact sensors

### DIFF
--- a/src/main/java/com/beowulfe/hap/accessories/ContactSensor.java
+++ b/src/main/java/com/beowulfe/hap/accessories/ContactSensor.java
@@ -1,0 +1,44 @@
+package com.beowulfe.hap.accessories;
+
+import com.beowulfe.hap.HomekitAccessory;
+import com.beowulfe.hap.HomekitCharacteristicChangeCallback;
+import com.beowulfe.hap.Service;
+import com.beowulfe.hap.accessories.properties.ContactState;
+import com.beowulfe.hap.impl.services.ContactSensorService;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A contact sensor that reports whether contact is detected or not. Typical
+ * contact sensors are window/door sensors. When contact is detected it means
+ * that the door/window is closed.
+ */
+public interface ContactSensor extends HomekitAccessory {
+
+    /**
+     * Retrieves the state of the contact. This is whether the contact is detected or not.
+     * Detected contact means door/window is closed.
+     *
+     * @return a future that will contain the contact's state
+     */
+    CompletableFuture<ContactState> getCurrentState();
+
+    @Override
+    default Collection<Service> getServices() {
+        return Collections.singleton(new ContactSensorService(this));
+    }
+
+    /**
+     * Subscribes to changes in the contact state.
+     *
+     * @param callback the function to call when the state changes.
+     */
+    void subscribeContactState(HomekitCharacteristicChangeCallback callback);
+
+    /**
+     * Unsubscribes from changes in the contact state.
+     */
+    void unsubscribeContactState();
+}

--- a/src/main/java/com/beowulfe/hap/accessories/MotionSensor.java
+++ b/src/main/java/com/beowulfe/hap/accessories/MotionSensor.java
@@ -1,0 +1,40 @@
+package com.beowulfe.hap.accessories;
+
+import com.beowulfe.hap.HomekitAccessory;
+import com.beowulfe.hap.HomekitCharacteristicChangeCallback;
+import com.beowulfe.hap.Service;
+import com.beowulfe.hap.impl.services.MotionSensorService;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A motion sensor that reports whether motion has been detected.
+ */
+public interface MotionSensor extends HomekitAccessory {
+
+    /**
+     * Retrieves the state of the motion sensor. If true then motion has been detected.
+     *
+     * @return a future that will contain the motion sensor's state
+     */
+    CompletableFuture<Boolean> getMotionDetected();
+
+    @Override
+    default Collection<Service> getServices() {
+        return Collections.singleton(new MotionSensorService(this));
+    }
+
+    /**
+     * Subscribes to changes in the motion sensor.
+     *
+     * @param callback the function to call when the state changes.
+     */
+    void subscribeMotionDetected(HomekitCharacteristicChangeCallback callback);
+
+    /**
+     * Unsubscribes from changes in the motion sensor.
+     */
+    void unsubscribeMotionDetected();
+}

--- a/src/main/java/com/beowulfe/hap/accessories/properties/ContactState.java
+++ b/src/main/java/com/beowulfe/hap/accessories/properties/ContactState.java
@@ -1,0 +1,30 @@
+package com.beowulfe.hap.accessories.properties;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public enum ContactState {
+
+    DETECTED(0),
+    NOT_DETECTED(1);
+
+    private final static Map<Integer, ContactState> reverse;
+    static {
+        reverse = Arrays.stream(ContactState.values()).collect(Collectors.toMap(ContactState::getCode, t -> t));
+    }
+
+    public static ContactState fromCode(Integer code) {
+        return reverse.get(code);
+    }
+
+    private final int code;
+
+    ContactState(int code) {
+        this.code = code;
+    }
+
+    public int getCode() {
+        return code;
+    }
+}

--- a/src/main/java/com/beowulfe/hap/impl/characteristics/contactsensor/ContactSensorStateCharacteristic.java
+++ b/src/main/java/com/beowulfe/hap/impl/characteristics/contactsensor/ContactSensorStateCharacteristic.java
@@ -1,0 +1,39 @@
+package com.beowulfe.hap.impl.characteristics.contactsensor;
+
+import com.beowulfe.hap.HomekitCharacteristicChangeCallback;
+import com.beowulfe.hap.accessories.ContactSensor;
+import com.beowulfe.hap.accessories.properties.ContactState;
+import com.beowulfe.hap.characteristics.EnumCharacteristic;
+import com.beowulfe.hap.characteristics.EventableCharacteristic;
+
+import java.util.concurrent.CompletableFuture;
+
+public class ContactSensorStateCharacteristic extends EnumCharacteristic implements EventableCharacteristic {
+
+    private final ContactSensor contactSensor;
+
+    public ContactSensorStateCharacteristic(ContactSensor contactSensor) {
+        super("0000006A-0000-1000-8000-0026BB765291", false, true, "Contact State", 1);
+        this.contactSensor = contactSensor;
+    }
+
+    @Override
+    protected CompletableFuture<Integer> getValue() {
+        return contactSensor.getCurrentState().thenApply(ContactState::getCode);
+    }
+
+    @Override
+    protected void setValue(Integer value) throws Exception {
+        //Read Only
+    }
+
+    @Override
+    public void subscribe(HomekitCharacteristicChangeCallback callback) {
+        contactSensor.subscribeContactState(callback);
+    }
+
+    @Override
+    public void unsubscribe() {
+        contactSensor.unsubscribeContactState();
+    }
+}

--- a/src/main/java/com/beowulfe/hap/impl/characteristics/motionsensor/MotionDetectedStateCharacteristic.java
+++ b/src/main/java/com/beowulfe/hap/impl/characteristics/motionsensor/MotionDetectedStateCharacteristic.java
@@ -1,0 +1,38 @@
+package com.beowulfe.hap.impl.characteristics.motionsensor;
+
+import com.beowulfe.hap.HomekitCharacteristicChangeCallback;
+import com.beowulfe.hap.accessories.MotionSensor;
+import com.beowulfe.hap.characteristics.BooleanCharacteristic;
+import com.beowulfe.hap.characteristics.EventableCharacteristic;
+
+import java.util.concurrent.CompletableFuture;
+
+public class MotionDetectedStateCharacteristic extends BooleanCharacteristic implements EventableCharacteristic {
+
+    private final MotionSensor motionSensor;
+
+    public MotionDetectedStateCharacteristic(MotionSensor motionSensor) {
+        super("00000022-0000-1000-8000-0026BB765291", false, true, "Motion Detected");
+        this.motionSensor = motionSensor;
+    }
+
+    @Override
+    protected CompletableFuture<Boolean> getValue() {
+        return motionSensor.getMotionDetected();
+    }
+
+    @Override
+    protected void setValue(Boolean value) throws Exception {
+        //Read Only
+    }
+
+    @Override
+    public void subscribe(HomekitCharacteristicChangeCallback callback) {
+        motionSensor.subscribeMotionDetected(callback);
+    }
+
+    @Override
+    public void unsubscribe() {
+        motionSensor.unsubscribeMotionDetected();
+    }
+}

--- a/src/main/java/com/beowulfe/hap/impl/services/ContactSensorService.java
+++ b/src/main/java/com/beowulfe/hap/impl/services/ContactSensorService.java
@@ -1,0 +1,14 @@
+package com.beowulfe.hap.impl.services;
+
+import com.beowulfe.hap.accessories.ContactSensor;
+import com.beowulfe.hap.impl.characteristics.common.Name;
+import com.beowulfe.hap.impl.characteristics.contactsensor.ContactSensorStateCharacteristic;
+
+public class ContactSensorService extends AbstractServiceImpl {
+
+    public ContactSensorService(ContactSensor contactSensor) {
+        super("00000080-0000-1000-8000-0026BB765291");
+        addCharacteristic(new Name(contactSensor));
+        addCharacteristic(new ContactSensorStateCharacteristic(contactSensor));
+    }
+}

--- a/src/main/java/com/beowulfe/hap/impl/services/MotionSensorService.java
+++ b/src/main/java/com/beowulfe/hap/impl/services/MotionSensorService.java
@@ -1,0 +1,14 @@
+package com.beowulfe.hap.impl.services;
+
+import com.beowulfe.hap.accessories.MotionSensor;
+import com.beowulfe.hap.impl.characteristics.common.Name;
+import com.beowulfe.hap.impl.characteristics.motionsensor.MotionDetectedStateCharacteristic;
+
+public class MotionSensorService extends AbstractServiceImpl {
+
+    public MotionSensorService(MotionSensor motionSensor) {
+        super("00000085-0000-1000-8000-0026BB765291");
+        addCharacteristic(new Name(motionSensor));
+        addCharacteristic(new MotionDetectedStateCharacteristic(motionSensor));
+    }
+}


### PR DESCRIPTION
I couldn't wait until the weekend so here are my changes for adding motion sensors and contact sensors support. I tested this and things appear correctly in HomeKit apps.

In a future PR I will explore adding support for battery status. That information does not seem to be that accurate in my zwave sensors so it is low priority for now.

If you want me to create 2 PRs, one for motion sensor and one for contact sensor let me know.

Thanks,
Gaston