### PR TITLE
We can now specify service name

### DIFF
--- a/src/main/java/com/beowulfe/hap/HomekitRoot.java
+++ b/src/main/java/com/beowulfe/hap/HomekitRoot.java
@@ -1,17 +1,16 @@
 package com.beowulfe.hap;
 
-import java.io.IOException;
-import java.net.InetAddress;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.beowulfe.hap.impl.HomekitRegistry;
 import com.beowulfe.hap.impl.HomekitWebHandler;
 import com.beowulfe.hap.impl.accessories.Bridge;
 import com.beowulfe.hap.impl.connections.HomekitClientConnectionFactoryImpl;
 import com.beowulfe.hap.impl.connections.SubscriptionManager;
 import com.beowulfe.hap.impl.jmdns.JmdnsHomekitAdvertiser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.InetAddress;
 
 /**
  * Provides advertising and handling for Homekit accessories. This class handles the advertising of Homekit accessories and 
@@ -69,7 +68,7 @@ public class HomekitRoot {
 	 */
 	void addAccessorySkipRangeCheck(HomekitAccessory accessory) {
 		this.registry.add(accessory);
-		logger.info("Added accessory "+accessory.getLabel());
+		logger.info("Added accessory " + accessory.getLabel());
 		if (started) {
 			registry.reset();
 			webHandler.resetConnections();
@@ -84,6 +83,7 @@ public class HomekitRoot {
 	 */
 	public void removeAccessory(HomekitAccessory accessory) {
 		this.registry.remove(accessory);
+		logger.info("Removed accessory " + accessory.getLabel());
 		if (started) {
 			registry.reset();
 			webHandler.resetConnections();

--- a/src/main/java/com/beowulfe/hap/accessories/LightSensor.java
+++ b/src/main/java/com/beowulfe/hap/accessories/LightSensor.java
@@ -1,0 +1,42 @@
+package com.beowulfe.hap.accessories;
+
+import com.beowulfe.hap.HomekitAccessory;
+import com.beowulfe.hap.HomekitCharacteristicChangeCallback;
+import com.beowulfe.hap.Service;
+import com.beowulfe.hap.impl.services.LightSensorService;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A light sensor that reports current ambient light level.
+ *
+ * @author Gaston Dombiak
+ */
+public interface LightSensor extends HomekitAccessory {
+
+    /**
+     * Retrieves the current ambient light level.
+     *
+     * @return a future that will contain the luminance level expressed in LUX.
+     */
+    CompletableFuture<Double> getCurrentAmbientLightLevel();
+
+    @Override
+    default Collection<Service> getServices() {
+        return Collections.singleton(new LightSensorService(this));
+    }
+
+    /**
+     * Subscribes to changes in the current ambient light level.
+     *
+     * @param callback the function to call when the state changes.
+     */
+    void subscribeCurrentAmbientLightLevel(HomekitCharacteristicChangeCallback callback);
+
+    /**
+     * Unsubscribes from changes in the current ambient light level.
+     */
+    void unsubscribeCurrentAmbientLightLevel();
+}

--- a/src/main/java/com/beowulfe/hap/impl/HomekitRegistry.java
+++ b/src/main/java/com/beowulfe/hap/impl/HomekitRegistry.java
@@ -1,20 +1,14 @@
 package com.beowulfe.hap.impl;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.beowulfe.hap.HomekitAccessory;
 import com.beowulfe.hap.Service;
 import com.beowulfe.hap.characteristics.Characteristic;
 import com.beowulfe.hap.impl.services.AccessoryInformationService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class HomekitRegistry {
 	
@@ -72,7 +66,11 @@ public class HomekitRegistry {
 	}
 	
 	public Map<Integer, Characteristic> getCharacteristics(Integer aid) {
-		return Collections.unmodifiableMap(characteristics.get(accessories.get(aid)));
+		Map<Integer, Characteristic> characteristics = this.characteristics.get(accessories.get(aid));
+		if (characteristics == null) {
+			return Collections.emptyMap();
+		}
+		return Collections.unmodifiableMap(characteristics);
 	}
 
 	public void add(HomekitAccessory accessory) {

--- a/src/main/java/com/beowulfe/hap/impl/characteristics/common/Name.java
+++ b/src/main/java/com/beowulfe/hap/impl/characteristics/common/Name.java
@@ -1,13 +1,12 @@
 package com.beowulfe.hap.impl.characteristics.common;
 
-import com.beowulfe.hap.HomekitAccessory;
 import com.beowulfe.hap.characteristics.StaticStringCharacteristic;
 
 public class Name extends StaticStringCharacteristic {
 	
-	public Name(HomekitAccessory accessory) {
+	public Name(String label) {
 		super("00000023-0000-1000-8000-0026BB765291",
 				"Name of the accessory",
-				accessory.getLabel());
+				label);
 	}
 }

--- a/src/main/java/com/beowulfe/hap/impl/characteristics/light/AmbientLightLevelCharacteristic.java
+++ b/src/main/java/com/beowulfe/hap/impl/characteristics/light/AmbientLightLevelCharacteristic.java
@@ -1,0 +1,39 @@
+package com.beowulfe.hap.impl.characteristics.light;
+
+import com.beowulfe.hap.HomekitCharacteristicChangeCallback;
+import com.beowulfe.hap.accessories.LightSensor;
+import com.beowulfe.hap.characteristics.EventableCharacteristic;
+import com.beowulfe.hap.characteristics.FloatCharacteristic;
+
+import java.util.concurrent.CompletableFuture;
+
+public class AmbientLightLevelCharacteristic extends FloatCharacteristic implements EventableCharacteristic {
+
+    private final LightSensor lightSensor;
+
+    public AmbientLightLevelCharacteristic(LightSensor lightSensor) {
+        super("0000006B-0000-1000-8000-0026BB765291", false, true, "Current ambient light level", 0.0001, 100000,
+                0.0001, "lux");
+        this.lightSensor = lightSensor;
+    }
+
+    @Override
+    protected void setValue(Double value) throws Exception {
+        //Read Only
+    }
+
+    @Override
+    public void subscribe(HomekitCharacteristicChangeCallback callback) {
+        lightSensor.subscribeCurrentAmbientLightLevel(callback);
+    }
+
+    @Override
+    public void unsubscribe() {
+        lightSensor.unsubscribeCurrentAmbientLightLevel();
+    }
+
+    @Override
+    protected CompletableFuture<Double> getDoubleValue() {
+        return lightSensor.getCurrentAmbientLightLevel();
+    }
+}

--- a/src/main/java/com/beowulfe/hap/impl/http/impl/AccessoryHandler.java
+++ b/src/main/java/com/beowulfe/hap/impl/http/impl/AccessoryHandler.java
@@ -87,11 +87,7 @@ class AccessoryHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
 	@Override
 	public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause)
 			throws Exception {
-		boolean errorLevel = true;
-		if (cause instanceof IOException) {
-			// Decide level of logging based on exception
-			errorLevel = !"Connection timed out".equals(cause.getMessage());
-		}
+		boolean errorLevel = !(cause instanceof IOException);
 		if (errorLevel) {
 			LOGGER.error("Exception caught in web handler", cause);
 		} else {

--- a/src/main/java/com/beowulfe/hap/impl/http/impl/BinaryHandler.java
+++ b/src/main/java/com/beowulfe/hap/impl/http/impl/BinaryHandler.java
@@ -52,11 +52,7 @@ public class BinaryHandler extends ByteToMessageCodec<ByteBuf> {
 	@Override
 	public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause)
 			throws Exception {
-		boolean errorLevel = true;
-		if (cause instanceof IOException) {
-			// Decide level of logging based on exception
-			errorLevel = !"Connection timed out".equals(cause.getMessage());
-		}
+		boolean errorLevel = !(cause instanceof IOException);
 		if (errorLevel) {
 			logger.error("Exception in binary handler", cause);
 		} else {

--- a/src/main/java/com/beowulfe/hap/impl/services/AbstractServiceImpl.java
+++ b/src/main/java/com/beowulfe/hap/impl/services/AbstractServiceImpl.java
@@ -17,18 +17,6 @@ abstract class AbstractServiceImpl implements Service {
 	private final List<Characteristic> characteristics = new LinkedList<>();
 
 	/**
-	 * This constructor has been deprecated and replaced with {@link #AbstractServiceImpl(String, HomekitAccessory)}.
-	 * Usages of this constructor will need to manually configure {@link Name} characteristic and
-	 * {@link BatteryLevelCharacteristic} if needed.
-	 *
-	 * @param type unique UUID of the service. This information can be obtained from HomeKit Accessory Simulator.
-     */
-	@Deprecated
-	public AbstractServiceImpl(String type) {
-		this(type, null);
-	}
-
-	/**
 	 * <p>Creates a new instance of this class with the specified UUID and {@link HomekitAccessory}.
 	 * Download and install <i>HomeKit Accessory Simulator</i> to discover the corresponding UUID for
 	 * the specific service.</p>
@@ -39,13 +27,14 @@ abstract class AbstractServiceImpl implements Service {
 	 *
 	 * @param type unique UUID of the service. This information can be obtained from HomeKit Accessory Simulator.
 	 * @param accessory HomeKit accessory exposed as a service.
+	 * @param serviceName name of the service. This information is usually the name of the accessory.
      */
-	public AbstractServiceImpl(String type, HomekitAccessory accessory) {
+	public AbstractServiceImpl(String type, HomekitAccessory accessory, String serviceName) {
 		this.type = type;
 
 		if (accessory != null) {
 			// Add name characteristic
-			addCharacteristic(new Name(accessory));
+			addCharacteristic(new Name(serviceName));
 
 			// If battery operated accessory then add BatteryLevelCharacteristic
 			if (accessory instanceof BatteryAccessory) {

--- a/src/main/java/com/beowulfe/hap/impl/services/AbstractServiceImpl.java
+++ b/src/main/java/com/beowulfe/hap/impl/services/AbstractServiceImpl.java
@@ -17,6 +17,19 @@ abstract class AbstractServiceImpl implements Service {
 	private final List<Characteristic> characteristics = new LinkedList<>();
 
 	/**
+	 * This constructor has been deprecated and replaced with
+	 * {@link #AbstractServiceImpl(String, HomekitAccessory, String)}. Usages of
+	 * this constructor will need to manually configure {@link Name} characteristic
+	 * and {@link BatteryLevelCharacteristic} if needed.
+	 *
+	 * @param type unique UUID of the service. This information can be obtained from HomeKit Accessory Simulator.
+	 */
+	@Deprecated
+	public AbstractServiceImpl(String type) {
+		this(type, null, null);
+	}
+
+	/**
 	 * <p>Creates a new instance of this class with the specified UUID and {@link HomekitAccessory}.
 	 * Download and install <i>HomeKit Accessory Simulator</i> to discover the corresponding UUID for
 	 * the specific service.</p>

--- a/src/main/java/com/beowulfe/hap/impl/services/AccessoryInformationService.java
+++ b/src/main/java/com/beowulfe/hap/impl/services/AccessoryInformationService.java
@@ -9,7 +9,11 @@ import com.beowulfe.hap.impl.characteristics.information.SerialNumber;
 public class AccessoryInformationService extends AbstractServiceImpl {
 
 	public AccessoryInformationService(HomekitAccessory accessory) throws Exception {
-		super("0000003E-0000-1000-8000-0026BB765291", accessory);
+		this(accessory, accessory.getLabel());
+	}
+
+	public AccessoryInformationService(HomekitAccessory accessory, String serviceName) throws Exception {
+		super("0000003E-0000-1000-8000-0026BB765291", accessory, serviceName);
 		addCharacteristic(new Manufacturer(accessory));
 		addCharacteristic(new Model(accessory));
 		addCharacteristic(new SerialNumber(accessory));

--- a/src/main/java/com/beowulfe/hap/impl/services/CarbonMonoxideSensorService.java
+++ b/src/main/java/com/beowulfe/hap/impl/services/CarbonMonoxideSensorService.java
@@ -6,7 +6,11 @@ import com.beowulfe.hap.impl.characteristics.carbonmonoxide.Carbon.CarbonMonoxid
 public class CarbonMonoxideSensorService extends AbstractServiceImpl {
 
     public CarbonMonoxideSensorService(CarbonMonoxideSensor carbonMonoxideSensor) {
-        super("0000007F-0000-1000-8000-0026BB765291", carbonMonoxideSensor);
+        this(carbonMonoxideSensor, carbonMonoxideSensor.getLabel());
+    }
+
+    public CarbonMonoxideSensorService(CarbonMonoxideSensor carbonMonoxideSensor, String serviceName) {
+        super("0000007F-0000-1000-8000-0026BB765291", carbonMonoxideSensor, serviceName);
         addCharacteristic(new CarbonMonoxideDetectedCharacteristic(carbonMonoxideSensor));
     }
 }

--- a/src/main/java/com/beowulfe/hap/impl/services/ContactSensorService.java
+++ b/src/main/java/com/beowulfe/hap/impl/services/ContactSensorService.java
@@ -6,7 +6,11 @@ import com.beowulfe.hap.impl.characteristics.contactsensor.ContactSensorStateCha
 public class ContactSensorService extends AbstractServiceImpl {
 
     public ContactSensorService(ContactSensor contactSensor) {
-        super("00000080-0000-1000-8000-0026BB765291", contactSensor);
+        this(contactSensor, contactSensor.getLabel());
+    }
+
+    public ContactSensorService(ContactSensor contactSensor, String serviceName) {
+        super("00000080-0000-1000-8000-0026BB765291", contactSensor, serviceName);
         addCharacteristic(new ContactSensorStateCharacteristic(contactSensor));
     }
 }

--- a/src/main/java/com/beowulfe/hap/impl/services/FanService.java
+++ b/src/main/java/com/beowulfe/hap/impl/services/FanService.java
@@ -8,7 +8,11 @@ import com.beowulfe.hap.impl.characteristics.fan.RotationSpeedCharacteristic;
 public class FanService extends AbstractServiceImpl {
 
 	public FanService(Fan fan) {
-		super("00000040-0000-1000-8000-0026BB765291", fan);
+		this(fan, fan.getLabel());
+	}
+
+	public FanService(Fan fan, String serviceName) {
+		super("00000040-0000-1000-8000-0026BB765291", fan, serviceName);
 		addCharacteristic(new PowerStateCharacteristic(
 				() -> fan.getFanPower(),
 				v -> fan.setFanPower(v),

--- a/src/main/java/com/beowulfe/hap/impl/services/GarageDoorService.java
+++ b/src/main/java/com/beowulfe/hap/impl/services/GarageDoorService.java
@@ -8,7 +8,11 @@ import com.beowulfe.hap.impl.characteristics.garage.TargetDoorStateCharacteristi
 public class GarageDoorService extends AbstractServiceImpl {
 
 	public GarageDoorService(GarageDoor door) {
-		super("00000041-0000-1000-8000-0026BB765291", door);
+		this(door, door.getLabel());
+	}
+
+	public GarageDoorService(GarageDoor door, String serviceName) {
+		super("00000041-0000-1000-8000-0026BB765291", door, serviceName);
 		addCharacteristic(new CurrentDoorStateCharacteristic(door));
 		addCharacteristic(new TargetDoorStateCharacteristic(door));
 		addCharacteristic(new ObstructionDetectedCharacteristic(() -> door.getObstructionDetected(),

--- a/src/main/java/com/beowulfe/hap/impl/services/HumiditySensorService.java
+++ b/src/main/java/com/beowulfe/hap/impl/services/HumiditySensorService.java
@@ -6,7 +6,11 @@ import com.beowulfe.hap.impl.characteristics.humiditysensor.CurrentRelativeHumid
 public class HumiditySensorService extends AbstractServiceImpl {
 	
 	public HumiditySensorService(HumiditySensor sensor) {
-		super("00000082-0000-1000-8000-0026BB765291", sensor);
+		this(sensor, sensor.getLabel());
+	}
+
+	public HumiditySensorService(HumiditySensor sensor, String serviceName) {
+		super("00000082-0000-1000-8000-0026BB765291", sensor, serviceName);
 		addCharacteristic(new CurrentRelativeHumidityCharacteristic(sensor));
 	}
 

--- a/src/main/java/com/beowulfe/hap/impl/services/LightSensorService.java
+++ b/src/main/java/com/beowulfe/hap/impl/services/LightSensorService.java
@@ -1,0 +1,16 @@
+package com.beowulfe.hap.impl.services;
+
+import com.beowulfe.hap.accessories.LightSensor;
+import com.beowulfe.hap.impl.characteristics.light.AmbientLightLevelCharacteristic;
+
+public class LightSensorService extends AbstractServiceImpl {
+
+    public LightSensorService(LightSensor lightSensor) {
+        this(lightSensor, lightSensor.getLabel());
+    }
+
+    public LightSensorService(LightSensor lightSensor, String serviceName) {
+        super("00000084-0000-1000-8000-0026BB765291", lightSensor, serviceName);
+        addCharacteristic(new AmbientLightLevelCharacteristic(lightSensor));
+    }
+}

--- a/src/main/java/com/beowulfe/hap/impl/services/LightbulbService.java
+++ b/src/main/java/com/beowulfe/hap/impl/services/LightbulbService.java
@@ -11,7 +11,11 @@ import com.beowulfe.hap.impl.characteristics.lightbulb.SaturationCharacteristic;
 public class LightbulbService extends AbstractServiceImpl {
 
 	public LightbulbService(Lightbulb lightbulb) {
-		super("00000043-0000-1000-8000-0026BB765291", lightbulb);
+		this(lightbulb, lightbulb.getLabel());
+	}
+
+	public LightbulbService(Lightbulb lightbulb, String serviceName) {
+		super("00000043-0000-1000-8000-0026BB765291", lightbulb, serviceName);
 		addCharacteristic(new PowerStateCharacteristic(
 				() -> lightbulb.getLightbulbPowerState(),
 				v -> lightbulb.setLightbulbPowerState(v),

--- a/src/main/java/com/beowulfe/hap/impl/services/LockMechanismService.java
+++ b/src/main/java/com/beowulfe/hap/impl/services/LockMechanismService.java
@@ -8,7 +8,11 @@ import com.beowulfe.hap.impl.characteristics.lock.mechanism.TargetLockMechanismS
 public class LockMechanismService extends AbstractServiceImpl {
 
 	public LockMechanismService(LockMechanism lock) {
-		super("00000045-0000-1000-8000-0026BB765291", lock);
+		this(lock, lock.getLabel());
+	}
+
+	public LockMechanismService(LockMechanism lock, String serviceName) {
+		super("00000045-0000-1000-8000-0026BB765291", lock, serviceName);
 		addCharacteristic(new CurrentLockMechanismStateCharacteristic(lock));
 		
 		if (lock instanceof LockableLockMechanism) {

--- a/src/main/java/com/beowulfe/hap/impl/services/MotionSensorService.java
+++ b/src/main/java/com/beowulfe/hap/impl/services/MotionSensorService.java
@@ -6,7 +6,11 @@ import com.beowulfe.hap.impl.characteristics.motionsensor.MotionDetectedStateCha
 public class MotionSensorService extends AbstractServiceImpl {
 
     public MotionSensorService(MotionSensor motionSensor) {
-        super("00000085-0000-1000-8000-0026BB765291", motionSensor);
+        this(motionSensor, motionSensor.getLabel());
+    }
+
+    public MotionSensorService(MotionSensor motionSensor, String serviceName) {
+        super("00000085-0000-1000-8000-0026BB765291", motionSensor, serviceName);
         addCharacteristic(new MotionDetectedStateCharacteristic(motionSensor));
     }
 }

--- a/src/main/java/com/beowulfe/hap/impl/services/OutletService.java
+++ b/src/main/java/com/beowulfe/hap/impl/services/OutletService.java
@@ -7,7 +7,11 @@ import com.beowulfe.hap.impl.characteristics.outlet.OutletInUseCharacteristic;
 public class OutletService extends AbstractServiceImpl {
 
 	public OutletService(Outlet outlet) {
-		super("00000047-0000-1000-8000-0026BB765291", outlet);
+		this(outlet, outlet.getLabel());
+	}
+
+	public OutletService(Outlet outlet, String serviceName) {
+		super("00000047-0000-1000-8000-0026BB765291", outlet, serviceName);
 		addCharacteristic(new PowerStateCharacteristic(
 				() -> outlet.getPowerState(),
 				v -> outlet.setPowerState(v),

--- a/src/main/java/com/beowulfe/hap/impl/services/SecuritySystemService.java
+++ b/src/main/java/com/beowulfe/hap/impl/services/SecuritySystemService.java
@@ -8,7 +8,11 @@ import com.beowulfe.hap.impl.characteristics.securitysystem.TargetSecuritySystem
 public class SecuritySystemService extends AbstractServiceImpl {
 
     public SecuritySystemService(SecuritySystem securitySystem) {
-        super("0000007E-0000-1000-8000-0026BB765291", securitySystem);
+        this(securitySystem, securitySystem.getLabel());
+    }
+
+    public SecuritySystemService(SecuritySystem securitySystem, String serviceName) {
+        super("0000007E-0000-1000-8000-0026BB765291", securitySystem, serviceName);
         addCharacteristic(new CurrentSecuritySystemStateCharacteristic(securitySystem));
         addCharacteristic(new TargetSecuritySystemStateCharacteristic(securitySystem));
         addCharacteristic(new SecuritySystemAlarmTypeCharacteristic(securitySystem));

--- a/src/main/java/com/beowulfe/hap/impl/services/SmokeSensorService.java
+++ b/src/main/java/com/beowulfe/hap/impl/services/SmokeSensorService.java
@@ -6,7 +6,11 @@ import com.beowulfe.hap.impl.characteristics.smokesensor.SmokeDetectedCharacteri
 public class SmokeSensorService extends AbstractServiceImpl {
 
     public SmokeSensorService(SmokeSensor smokeSensor) {
-        super("00000087-0000-1000-8000-0026BB765291", smokeSensor);
+        this(smokeSensor, smokeSensor.getLabel());
+    }
+
+    public SmokeSensorService(SmokeSensor smokeSensor, String serviceName) {
+        super("00000087-0000-1000-8000-0026BB765291", smokeSensor, serviceName);
         addCharacteristic(new SmokeDetectedCharacteristic(smokeSensor));
     }
 }

--- a/src/main/java/com/beowulfe/hap/impl/services/SwitchService.java
+++ b/src/main/java/com/beowulfe/hap/impl/services/SwitchService.java
@@ -6,7 +6,11 @@ import com.beowulfe.hap.impl.characteristics.common.PowerStateCharacteristic;
 public class SwitchService extends AbstractServiceImpl {
 
 	public SwitchService(Switch switchAccessory) {
-		super("00000049-0000-1000-8000-0026BB765291", switchAccessory);
+		this(switchAccessory, switchAccessory.getLabel());
+	}
+
+	public SwitchService(Switch switchAccessory, String serviceName) {
+		super("00000049-0000-1000-8000-0026BB765291", switchAccessory, serviceName);
 		addCharacteristic(new PowerStateCharacteristic(
 				() -> switchAccessory.getSwitchState(),
 				v -> switchAccessory.setSwitchState(v),

--- a/src/main/java/com/beowulfe/hap/impl/services/TemperatureSensorService.java
+++ b/src/main/java/com/beowulfe/hap/impl/services/TemperatureSensorService.java
@@ -6,7 +6,11 @@ import com.beowulfe.hap.impl.characteristics.thermostat.CurrentTemperatureCharac
 public class TemperatureSensorService extends AbstractServiceImpl {
 	
 	public TemperatureSensorService(TemperatureSensor sensor) {
-		super("0000008A-0000-1000-8000-0026BB765291", sensor);
+		this(sensor, sensor.getLabel());
+	}
+
+	public TemperatureSensorService(TemperatureSensor sensor, String serviceName) {
+		super("0000008A-0000-1000-8000-0026BB765291", sensor, serviceName);
 		addCharacteristic(new CurrentTemperatureCharacteristic(sensor));
 	}
 

--- a/src/main/java/com/beowulfe/hap/impl/services/ThermostatService.java
+++ b/src/main/java/com/beowulfe/hap/impl/services/ThermostatService.java
@@ -8,7 +8,11 @@ import com.beowulfe.hap.impl.characteristics.thermostat.*;
 public class ThermostatService extends AbstractServiceImpl {
 
 	public ThermostatService(BasicThermostat thermostat) {
-		super("0000004A-0000-1000-8000-0026BB765291", thermostat);
+		this(thermostat, thermostat.getLabel());
+	}
+
+	public ThermostatService(BasicThermostat thermostat, String serviceName) {
+		super("0000004A-0000-1000-8000-0026BB765291", thermostat, serviceName);
 		addCharacteristic(new CurrentHeatingCoolingModeCharacteristic(thermostat));
 		addCharacteristic(new CurrentTemperatureCharacteristic(thermostat));
 		addCharacteristic(new TargetHeatingCoolingModeCharacteristic(thermostat));

--- a/src/main/java/com/beowulfe/hap/impl/services/WindowCoveringService.java
+++ b/src/main/java/com/beowulfe/hap/impl/services/WindowCoveringService.java
@@ -9,7 +9,11 @@ import com.beowulfe.hap.impl.characteristics.windowcovering.*;
 public class WindowCoveringService extends AbstractServiceImpl {
 
 	public WindowCoveringService(WindowCovering windowCovering) {
-		super("0000008C-0000-1000-8000-0026BB765291", windowCovering);
+		this(windowCovering, windowCovering.getLabel());
+	}
+
+	public WindowCoveringService(WindowCovering windowCovering, String serviceName) {
+		super("0000008C-0000-1000-8000-0026BB765291", windowCovering, serviceName);
 		addCharacteristic(new CurrentPositionCharacteristic(windowCovering));
 		addCharacteristic(new HoldPositionCharacteristic(windowCovering));
 		addCharacteristic(new PositionStateCharacteristic(windowCovering));
@@ -17,7 +21,7 @@ public class WindowCoveringService extends AbstractServiceImpl {
 		addCharacteristic(new ObstructionDetectedCharacteristic(() -> windowCovering.getObstructionDetected(),
 				c -> windowCovering.subscribeObstructionDetected(c),
 				() -> windowCovering.unsubscribeObstructionDetected()));
-		
+
 		if (windowCovering instanceof HorizontalTiltingWindowCovering) {
 			addCharacteristic(new CurrentHorizontalTiltAngleCharacteristic(
 					(HorizontalTiltingWindowCovering) windowCovering));
@@ -31,5 +35,4 @@ public class WindowCoveringService extends AbstractServiceImpl {
 					(VerticalTiltingWindowCovering) windowCovering));
 		}
 	}
-
 }


### PR DESCRIPTION
Andy,

Here are 2 small improvements:
1. It is now possible to specify service name. Still defaults to accessory label
2. Log IOExceptions using DEBUG level. Before it was only one type of timeout.

I have an accessory that  offers 2 services and both services were appearing with the same name (the name of the accessory). I added a new constructor to ServicesImpl so that we can pass a serviceName. Old constructor is still around and defaults to accessory label. 
Fine-prints: 1) Had to remove the deprecated constructor in AbstractServiceImpl. I think you were ok with this. 2) Changed constructor of Name to accept a String instead of a HomekitAccessory.

Noticed a few more "noisy" entries in the log around IOExceptions so went ahead and change code to log with DEBUG all IOExceptions instead of just "Connection timed out".

Let me know if you are ok with these changes.
Thanks,
Gaston