### PR TITLE
Fixing TargetHeatingCoolingModeCharacteristic

### DIFF
--- a/src/main/java/com/beowulfe/hap/impl/characteristics/thermostat/TargetHeatingCoolingModeCharacteristic.java
+++ b/src/main/java/com/beowulfe/hap/impl/characteristics/thermostat/TargetHeatingCoolingModeCharacteristic.java
@@ -12,7 +12,7 @@ public class TargetHeatingCoolingModeCharacteristic extends
 	private final BasicThermostat thermostat;
 	
 	public TargetHeatingCoolingModeCharacteristic(BasicThermostat thermostat) {
-		super("00000033-0000-1000-8000-0026BB765291", false, "Target Mode");
+		super("00000033-0000-1000-8000-0026BB765291", true, "Target Mode");
 		this.thermostat = thermostat;
 	}
 


### PR DESCRIPTION
Fixing issue with the targetMode of Thermostat implementations not being able to be set due to setting isWritable = false on TargetHeatingCoolingModeCharacteristic superclass.