### PR TITLE
Returning value out of range made accessory disappear

### DIFF
--- a/src/main/java/com/beowulfe/hap/impl/characteristics/carbonmonoxide/CarbonMonoxideDetectedCharacteristic.java
+++ b/src/main/java/com/beowulfe/hap/impl/characteristics/carbonmonoxide/CarbonMonoxideDetectedCharacteristic.java
@@ -1,4 +1,4 @@
-package com.beowulfe.hap.impl.characteristics.carbonmonoxide.Carbon;
+package com.beowulfe.hap.impl.characteristics.carbonmonoxide;
 
 import com.beowulfe.hap.HomekitCharacteristicChangeCallback;
 import com.beowulfe.hap.accessories.CarbonMonoxideSensor;

--- a/src/main/java/com/beowulfe/hap/impl/services/CarbonMonoxideSensorService.java
+++ b/src/main/java/com/beowulfe/hap/impl/services/CarbonMonoxideSensorService.java
@@ -1,7 +1,7 @@
 package com.beowulfe.hap.impl.services;
 
 import com.beowulfe.hap.accessories.CarbonMonoxideSensor;
-import com.beowulfe.hap.impl.characteristics.carbonmonoxide.Carbon.CarbonMonoxideDetectedCharacteristic;
+import com.beowulfe.hap.impl.characteristics.carbonmonoxide.CarbonMonoxideDetectedCharacteristic;
 
 public class CarbonMonoxideSensorService extends AbstractServiceImpl {
 


### PR DESCRIPTION
Andy,

After some detective work I was able to narrow down the reason the accessory was disappearing. I'm still running more tests to confirm this was the reason but so far after 24 hours it is holding fine. The problem was not in the code but in the data the accessory was returning. To be more precise, AmbientLightLevelCharacteristic said that values were in the range between 0.0001 and 100000. My zwave sensor was returning 0.0 when it was dark. Seems like HK runs some background check at some moment and if an accessory is returning some invalid data (e.g. value out of range) then it is declared as "incompatible" (I guess) and is silently removed.

I added a simple check in the library to detect out of range values (for Floats) and return closest value within range. The problem is also logged like this:

> 2016-08-27 22:53:41.755  WARN 84874 --- [onPool-worker-5] c.b.h.c.FloatCharacteristic              : Detected value out of range 0.0. Returning min value instead. Characteristic com.beowulfe.hap.impl.characteristics.light.AmbientLightLevelCharacteristic@3a6d0e82

It would be nice to also check range for IntegerCharacteristic but a bigger refactoring is needed that could break compatibility so I left that one alone.

Columbo can now take a break from this long investigation. :)