### PR TITLE
Update the SecuritySystemAlarmType enum

### DIFF
--- a/src/main/java/com/beowulfe/hap/accessories/properties/SecuritySystemAlarmType.java
+++ b/src/main/java/com/beowulfe/hap/accessories/properties/SecuritySystemAlarmType.java
@@ -16,7 +16,7 @@ public enum SecuritySystemAlarmType {
     /**
      * Alarm conditions are cleared
      */
-    CLEARED(0),
+    NO_ALARM(0),
     /**
      * Alarm type is not known
      */


### PR DESCRIPTION
Another small tweak to clean up an inconsistency [with the HomeKit documentation](https://developer.apple.com/documentation/homekit/hmcharacteristicvaluesecuritysystemalarmtype/1648623-noalarm) that I came across.

@beowulfe should be a quick one 😄 