### PR TITLE
fix reading encrypted frames that don't line up with network frames

### DIFF
--- a/src/main/java/com/beowulfe/hap/impl/connections/LengthPrefixedByteArrayProcessor.java
+++ b/src/main/java/com/beowulfe/hap/impl/connections/LengthPrefixedByteArrayProcessor.java
@@ -74,7 +74,7 @@ class LengthPrefixedByteArrayProcessor {
       results.add(buffer.toByteArray());
       buffer.reset();
       targetLength = 0;
-      if (pos + toWrite > data.length) {
+      if (pos + toWrite < data.length) {
         step(data, pos + toWrite, results);
       }
     } else {


### PR DESCRIPTION
we want to call step again if there's remaining data. pos + toWrite
is what we consumed from this network frame to complete the encrypted
frame. so if it's less than the total network frame (data.length),
then call step again.